### PR TITLE
Centralize definition of test main and include cstdint in several hea…

### DIFF
--- a/src/algorithms/dynamic_programming/coin_change.h
+++ b/src/algorithms/dynamic_programming/coin_change.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/dynamic_programming/fib.h
+++ b/src/algorithms/dynamic_programming/fib.h
@@ -4,6 +4,8 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <math.h>
+#include <cstdint>
 #endif
 
 /**
@@ -62,6 +64,6 @@ int64_t fibonacci_bottom_up(int64_t n) {
  */
 int64_t fibonacci_binet(int64_t n) {
   double phi = (std::sqrt(5) + 1) / 2;
-  return std::round(std::pow(phi, n) / sqrt(5));
+  return (int64_t) std::round(std::pow(phi, n) / sqrt(5));
 }
 #endif

--- a/src/algorithms/dynamic_programming/kadane.h
+++ b/src/algorithms/dynamic_programming/kadane.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/dynamic_programming/lcs.h
+++ b/src/algorithms/dynamic_programming/lcs.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <string>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/dynamic_programming/lis.h
+++ b/src/algorithms/dynamic_programming/lis.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/number_theory/gcd.h
+++ b/src/algorithms/number_theory/gcd.h
@@ -3,6 +3,7 @@
 
 #ifdef __cplusplus
 #include <iostream>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/searching/binary_search.h
+++ b/src/algorithms/searching/binary_search.h
@@ -3,6 +3,8 @@
 
 #ifdef __cplusplus
 #include <iostream>
+#include <vector>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/searching/jump_search.h
+++ b/src/algorithms/searching/jump_search.h
@@ -3,6 +3,9 @@
 
 #ifdef __cplusplus
 #include <iostream>
+#include <cstdint>
+#include <vector>
+#include <cmath>
 #endif
 
 /**

--- a/src/algorithms/searching/linear_search.h
+++ b/src/algorithms/searching/linear_search.h
@@ -3,6 +3,7 @@
 
 #ifdef __cplusplus
 #include <iostream>
+#include <vector>
 #endif
 
 /**

--- a/src/algorithms/sorting/bubble_sort.h
+++ b/src/algorithms/sorting/bubble_sort.h
@@ -3,6 +3,8 @@
 
 #ifdef __cplusplus
 #include <iostream>
+#include <cstdint>
+#include <vector>
 #endif
 
 /**

--- a/src/algorithms/sorting/bucket_sort.h
+++ b/src/algorithms/sorting/bucket_sort.h
@@ -4,6 +4,8 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <cstdint>
+#include <algorithm>
 #endif
 
 /**

--- a/src/algorithms/sorting/insertion_sort.h
+++ b/src/algorithms/sorting/insertion_sort.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/sorting/radix_sort.h
+++ b/src/algorithms/sorting/radix_sort.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <algorithm>
 #endif
 
 template <typename T> void radix_sort(std::vector<T> &arr) {

--- a/src/algorithms/sorting/selection_sort.h
+++ b/src/algorithms/sorting/selection_sort.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <vector>
+#include <cstdint>
 #endif
 
 /**

--- a/src/algorithms/string/edit_distance.h
+++ b/src/algorithms/string/edit_distance.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 #include <iostream>
 #include <string>
+#include <cstdint>
 #endif
 
 /**

--- a/src/classes/tree/interval_tree.h
+++ b/src/classes/tree/interval_tree.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#include <functional>
 #endif
 
 /**

--- a/src/classes/tree/splay_tree.h
+++ b/src/classes/tree/splay_tree.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#include <functional>
 #endif
 
 /**

--- a/tests/algorithms/dynamic_programming/coin_change.cc
+++ b/tests/algorithms/dynamic_programming/coin_change.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/dynamic_programming/coin_change.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/dynamic_programming/fibonacci.cc
+++ b/tests/algorithms/dynamic_programming/fibonacci.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/dynamic_programming/fib.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/dynamic_programming/kadane.cc
+++ b/tests/algorithms/dynamic_programming/kadane.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/dynamic_programming/kadane.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/dynamic_programming/lcs.cc
+++ b/tests/algorithms/dynamic_programming/lcs.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/dynamic_programming/lcs.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/dynamic_programming/lis.cc
+++ b/tests/algorithms/dynamic_programming/lis.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/dynamic_programming/lis.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/number_theory/gcd.cc
+++ b/tests/algorithms/number_theory/gcd.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/number_theory/gcd.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/searching/binary_search.cc
+++ b/tests/algorithms/searching/binary_search.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/searching/binary_search.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/searching/exponential_search.cc
+++ b/tests/algorithms/searching/exponential_search.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/searching/exponential_search.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/searching/jump_search.cc
+++ b/tests/algorithms/searching/jump_search.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/searching/jump_search.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/searching/linear_search.cc
+++ b/tests/algorithms/searching/linear_search.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/searching/linear_search.h"
 #include "../../catch2/catch.hpp"
 

--- a/tests/algorithms/sorting/bubble_sort.cc
+++ b/tests/algorithms/sorting/bubble_sort.cc
@@ -1,4 +1,4 @@
-#include "../../../src/algorithms/sorting/merge_sort.h"
+#include "../../../src/algorithms/sorting/bubble_sort.h"
 #include "../../catch2/catch.hpp"
 #include <random>
 #include <vector>
@@ -9,6 +9,6 @@ TEST_CASE("testing merge sort") {
         int random = rand() % 50000;
         v.push_back(i - random);
     }
-    merge_sort(v.begin(), v.end());
+    bubble_sort(v);
     REQUIRE(std::is_sorted(v.begin(), v.end()) == true);
 }

--- a/tests/algorithms/sorting/bucket_sort.cc
+++ b/tests/algorithms/sorting/bucket_sort.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/sorting/bucket_sort.h"
 #include "../../catch2/catch.hpp"
 #include <random>

--- a/tests/algorithms/sorting/insertion_sort.cc
+++ b/tests/algorithms/sorting/insertion_sort.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/sorting/insertion_sort.h"
 #include "../../catch2/catch.hpp"
 #include <random>

--- a/tests/algorithms/sorting/quick_sort.cc
+++ b/tests/algorithms/sorting/quick_sort.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/sorting/quick_sort.h"
 #include "../../catch2/catch.hpp"
 #include <random>

--- a/tests/algorithms/sorting/selection_sort.cc
+++ b/tests/algorithms/sorting/selection_sort.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/sorting/selection_sort.h"
 #include "../../catch2/catch.hpp"
 #include <random>

--- a/tests/algorithms/string/min_distance.cc
+++ b/tests/algorithms/string/min_distance.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../../src/algorithms/string/edit_distance.h"
 #include "../../catch2/catch.hpp"
 #include <string>

--- a/tests/graph/graph.cc
+++ b/tests/graph/graph.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/graph/graph.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/graph/weighted_graph.cc
+++ b/tests/graph/weighted_graph.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/graph/graph.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/hash_table/hash_table.cc
+++ b/tests/hash_table/hash_table.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/hash_table/hash_table.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/list/circular_linked_list.cc
+++ b/tests/list/circular_linked_list.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/list/circular_linked_list.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/list/doubly_list.cc
+++ b/tests/list/doubly_list.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/list/doubly_linked_list.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/list/list.cc
+++ b/tests/list/list.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/list/linked_list.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/list/skip_list.cc
+++ b/tests/list/skip_list.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/list/skip_list.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/queue/dequeue_list.cc
+++ b/tests/queue/dequeue_list.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/queue/dequeue_list.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/stack/stack_list.cc
+++ b/tests/stack/stack_list.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/stack/stack_list.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"

--- a/tests/tree/avl.cc
+++ b/tests/tree/avl.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/tree/avl_tree.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/tree/bst.cc
+++ b/tests/tree/bst.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/tree/bst.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/tree/interval_tree.cc
+++ b/tests/tree/interval_tree.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/tree/interval_tree.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/tree/splay_tree.cc
+++ b/tests/tree/splay_tree.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/tree/splay_tree.h"
 #include "../catch2/catch.hpp"
 #include <string>

--- a/tests/tree/trie.cc
+++ b/tests/tree/trie.cc
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "../../src/classes/tree/trie.h"
 #include "../catch2/catch.hpp"
 #include <string>


### PR DESCRIPTION
…ders

Removed CATCH_CONFIG_MAIN from individual test files and consolidated it into a single test_main.cc. This simplifies the test configuration and reduces the number of files defining the main function for the Catch2 test suite. Additionally, the cstdint header was included in several algorithm and data structure headers to ensure the int64_t type is recognized. A new Bubble sort test was also added.