### PR TITLE
Added climits in kadane

### DIFF
--- a/src/algorithms/dynamic_programming/kadane.h
+++ b/src/algorithms/dynamic_programming/kadane.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
+#include <climits>
 #endif
 
 /**


### PR DESCRIPTION
- #23 

Added climits to kadane.h.
It is needed in linux for INT_MIN