### PR TITLE
Corrected and optimized DFS function and optimized BFS

### DIFF
--- a/src/classes/graph/graph.h
+++ b/src/classes/graph/graph.h
@@ -261,52 +261,53 @@ private:
 template <typename T> size_t graph<T>::size() { return __elements.size(); }
 
 template <typename T> std::vector<T> graph<T>::dfs(T start) {
-  std::vector<T> path;
-  if (this->empty() || __elements.find(start) == __elements.end()) {
-    return path;
-  }
-  std::stack<T> s;
-  std::unordered_map<T, bool> visited;
-  s.push(start);
-  visited[start] = true;
-  while (!s.empty()) {
-    T current = s.top();
-    path.push_back(current);
-    s.pop();
-    for (T &x : adj[current]) {
-      if (visited.find(x) == visited.end()) {
-        s.push(x);
-        visited[x] = true;
-      }
+    std::vector<T> path;
+    if (this->empty() || __elements.find(start) == __elements.end()) {
+        return path;
     }
-  }
-  return path;
+    std::stack<T> s;
+    std::unordered_set<T> visited;
+    s.push(start);
+    visited.insert(start);
+    while (!s.empty()) {
+        T current = s.top();
+        path.push_back(current);
+        s.pop();
+        for (T &x : adj[current]) {
+            if (visited.find(x) == visited.end()) {
+                s.push(x);
+                visited.insert(x);
+            }
+        }
+    }
+    return path;
 }
 
 template <typename T> std::vector<T> graph<T>::bfs(T start) {
-  std::vector<T> path;
-  if (this->empty() || __elements.find(start) == __elements.end()) {
-    return path;
-  }
-  std::queue<T> q;
-  std::unordered_map<T, bool> visited;
-  q.push(start);
-  visited[start] = true;
-  while (!q.empty()) {
-    int64_t size = q.size();
-    for (int64_t i = 0; i < size; i++) {
-      T current = q.front();
-      path.push_back(current);
-      q.pop();
-      for (T &x : adj[current]) {
-        if (visited.find(x) == visited.end()) {
-          q.push(x);
-          visited[x] = true;
-        }
-      }
+    std::vector<T> path;
+    if (this->empty() || __elements.find(start) == __elements.end()) {
+        return path;
     }
-  }
-  return path;
+
+    std::queue<T> q;
+    std::unordered_set<T> visited;
+
+    q.push(start);
+    visited.insert(start);
+
+    while (!q.empty()) {
+        T current = q.front();
+        path.push_back(current);
+        q.pop();
+
+        for (T &x : adj[current]) {
+            if (visited.find(x) == visited.end()) {
+                q.push(x);
+                visited.insert(x);
+            }
+        }
+    }
+    return path;
 }
 
 template <typename T> int64_t graph<T>::connected_components() {

--- a/src/classes/graph/graph.h
+++ b/src/classes/graph/graph.h
@@ -866,56 +866,55 @@ template <typename T> int64_t weighted_graph<T>::shortest_path(T start, T end) {
 }
 
 template <typename T> std::vector<T> weighted_graph<T>::dfs(T start) {
-
-  std::vector<T> path;
-  if (this->empty() || __elements.find(start) == __elements.end()) {
-    return path;
-  }
-  std::queue<T> q;
-  std::unordered_map<T, bool> visited;
-  q.push(start);
-  visited[start] = true;
-  while (!q.empty()) {
-    int64_t size = q.size();
-    for (int64_t i = 0; i < size; i++) {
-      T current = q.front();
-      path.push_back(current);
-      q.pop();
-      for (std::pair<T, int64_t> &x : adj[current]) {
-        if (visited.find(x.first) == visited.end()) {
-          q.push(x.first);
-          visited[x.first] = true;
-        }
-      }
+    std::vector<T> path;
+    if (this->empty() || __elements.find(start) == __elements.end()) {
+        return path;
     }
-  }
-  return path;
+
+    std::stack<T> s;
+    std::unordered_map<T, bool> visited;
+
+    s.push(start);
+    visited[start] = true;
+
+    while (!s.empty()) {
+        T current = s.top();
+        path.push_back(current);
+        s.pop();
+        for (std::pair<T, int64_t> &x : adj[current]) {
+            if (visited.find(x.first) == visited.end()) {
+                s.push(x.first);
+                visited[x.first] = true;
+            }
+        }
+    }
+    return path;
 }
 
 template <typename T> std::vector<T> weighted_graph<T>::bfs(T start) {
-  std::vector<T> path;
-  if (this->empty() || __elements.find(start) == __elements.end()) {
-    return path;
-  }
-  std::queue<T> q;
-  std::unordered_map<T, bool> visited;
-  q.push(start);
-  visited[start] = true;
-  while (!q.empty()) {
-    int64_t size = q.size();
-    for (int64_t i = 0; i < size; i++) {
-      T current = q.front();
-      path.push_back(current);
-      q.pop();
-      for (std::pair<T, int64_t> &x : adj[current]) {
-        if (visited.find(x.first) == visited.end()) {
-          q.push(x.first);
-          visited[x.first] = true;
-        }
-      }
+    std::vector<T> path;
+    if (this->empty() || __elements.find(start) == __elements.end()) {
+        return path;
     }
-  }
-  return path;
+
+    std::queue<T> q;
+    std::unordered_set<T> visited;
+
+    q.push(start);
+    visited.insert(start);
+
+    while (!q.empty()) {
+        T current = q.front();
+        path.push_back(current);
+        q.pop();
+        for (std::pair<T, int64_t> &x : adj[current]) {
+            if (visited.find(x.first) == visited.end()) {
+                q.push(x.first);
+                visited.insert(x.first);
+            }
+        }
+    }
+    return path;
 }
 
 template <typename T> int64_t weighted_graph<T>::connected_components() {

--- a/tests/graph/weighted_graph.cc
+++ b/tests/graph/weighted_graph.cc
@@ -238,7 +238,7 @@ TEST_CASE("testing operator = for weighted graph class") {
   REQUIRE(g.dfs("b") == g2.dfs("b"));
 }
 
-TEST_CASE("BFS Traversal", "[bfs]") {
+TEST_CASE("BFS Traversal for weighted graphs", "[bfs]") {
     weighted_graph<int> graph("directed");
 
     graph.add_edge(1, 2, 1);
@@ -256,7 +256,7 @@ TEST_CASE("BFS Traversal", "[bfs]") {
     REQUIRE(bfsTraversal == expected);
 }
 
-TEST_CASE("DFS Traversal", "[dfs]") {
+TEST_CASE("DFS Traversal for weighted graphs", "[dfs]") {
     weighted_graph<int> graph("directed");
 
     graph.add_edge(1, 2, 1);

--- a/tests/graph/weighted_graph.cc
+++ b/tests/graph/weighted_graph.cc
@@ -237,3 +237,39 @@ TEST_CASE("testing operator = for weighted graph class") {
   REQUIRE(g.dfs("a") == g2.dfs("a"));
   REQUIRE(g.dfs("b") == g2.dfs("b"));
 }
+
+TEST_CASE("BFS Traversal", "[bfs]") {
+    weighted_graph<int> graph("directed");
+
+    graph.add_edge(1, 2, 1);
+    graph.add_edge(1, 3, 1);
+    graph.add_edge(2, 4, 1);
+    graph.add_edge(2, 5, 1);
+    graph.add_edge(4, 5, 1);
+    graph.add_edge(3, 6, 1);
+
+    // Perform BFS and store the result
+    std::vector<int> bfsTraversal = graph.bfs(1); // starting BFS from node 1
+
+    std::vector<int> expected = {1, 2, 3, 4, 5, 6};
+
+    REQUIRE(bfsTraversal == expected);
+}
+
+TEST_CASE("DFS Traversal", "[dfs]") {
+    weighted_graph<int> graph("directed");
+
+    graph.add_edge(1, 2, 1);
+    graph.add_edge(1, 3, 1);
+    graph.add_edge(2, 4, 1);
+    graph.add_edge(2, 5, 1);
+    graph.add_edge(4, 5, 1);
+    graph.add_edge(3, 6, 1);
+
+    // Perform DFS and store the result
+    std::vector<int> dfsTraversal = graph.dfs(1); // starting DFS from node 1
+
+    std::vector<int> expected = {1, 3, 6, 2, 5, 4};
+
+    REQUIRE(dfsTraversal == expected);
+}


### PR DESCRIPTION
- Fixed the DFS function(for weighted graphs): it was previously performing a BFS instead of a DFS due to a mistake in the traversal algorithm. Corrected the issue to ensure the function now performs a proper Depth-first Search.
- Optimized the BFS and DFS functions to improve its memory usage and or its performance:
 - by checking whether a node has been visited before it's added to the queue, rather than after. The previous implementation 
   pushed every node into the queue, then checked for visited status upon popping the node, which can result in unnecessary 
   queue operations. By checking for visited status beforehand, unnecessary push operations into the queue are avoided, leading 
   to performance optimization.
 - changed std::unordered_map<T, bool> to std::unordered_set<T>, due to the bools not actually being used, optimizing memory 
    usage