### PR TITLE
Undefined __min macro

### DIFF
--- a/src/classes/heap/min_heap.h
+++ b/src/classes/heap/min_heap.h
@@ -7,6 +7,9 @@
 #include <vector>
 #endif
 
+// This is needed to avoid conflict with windows __min macro
+#undef __min
+
 /**
  * @brief min heap class
  *


### PR DESCRIPTION
- #27 

No need for rename. Just undefined the windows macro.