### PR TITLE
Update mat_1d.h: Import vector library and fix constructor

### DIFF
--- a/src/linalg/mat_1d.h
+++ b/src/linalg/mat_1d.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <climits>
 #include <optional>
+#include <vector>
 #include "../algorithms/sorting/quick_sort.h"
 #endif
 
@@ -55,7 +56,6 @@ public:
     for(size_t i = 0; i<__size; ++i){
       arr[i] = val;
     }
-    return *(this);
   }
 
   /**


### PR DESCRIPTION
The vector library has been imported into 'mat_1d.h'. Moreover, the 'return *(this);' line in the constructor has been removed. This not only resolved a compilation error, but also prevents potential issues tied to invoking methods on temporary objects.