### PR TITLE
Added visualise for red black tree

### DIFF
--- a/examples/tree/red_black_tree.cc
+++ b/examples/tree/red_black_tree.cc
@@ -1,0 +1,25 @@
+#ifdef __cplusplus
+#include "../../src/classes/tree/red_black_tree.h"
+#include <iostream>
+#endif
+
+int main() {
+    red_black_tree<char> rb({'a','b','c'});
+    rb.insert('d');
+    rb.insert('t');
+    rb.remove('b');
+    // Will print an inorder traversal.
+    cout<<rb<<std::endl;
+
+    // Will return a preorder traversal.
+    std::vector<char> v = rb.preorder();
+    for(int i=0;i<v.size();i++)
+        std::cout<<v[i]<<" ";
+    std::cout<<std::endl;
+
+    
+    // example for visualise.
+    red_black_tree<int> rb({1, 2, 3, 4, 5, 6, 7, 8, 9});
+    rb.visualize();
+    return 0;
+}

--- a/examples/tree/red_black_tree.cc
+++ b/examples/tree/red_black_tree.cc
@@ -8,18 +8,18 @@ int main() {
     rb.insert('d');
     rb.insert('t');
     rb.remove('b');
-    // Will print an inorder traversal.
+    // Will print the inorder traversal.
     cout<<rb<<std::endl;
 
-    // Will return a preorder traversal.
+    // Will return the preorder traversal.
     std::vector<char> v = rb.preorder();
     for(int i=0;i<v.size();i++)
         std::cout<<v[i]<<" ";
     std::cout<<std::endl;
 
     
-    // example for visualise.
-    red_black_tree<int> rb({1, 2, 3, 4, 5, 6, 7, 8, 9});
-    rb.visualize();
+    // example for visualize.
+    red_black_tree<int> rb2({1, 2, 3, 4, 5, 6, 7, 8, 9});
+    rb2.visualize();
     return 0;
 }

--- a/src/classes/tree/red_black_tree.h
+++ b/src/classes/tree/red_black_tree.h
@@ -2,6 +2,7 @@
 #define RED_BLACK_TREE_H
 
 #ifdef __cplusplus
+#include "../../visualization/tree_visual/tree_visualization.h"
 #include <memory>
 #include <bitset>
 #include <vector>
@@ -260,6 +261,32 @@ private:
       _preorder(callback, t_node->right);
     }
   }
+
+  std::string _vis_gen(std::shared_ptr<node> t_node, T parent_info) {
+    std::string _s;
+    if (std::is_same_v<T, char> || std::is_same_v<T, std::string>) {
+      _s += t_node->info + " [shape=circle fontcolor=black color=";
+      if(t_node->is_red == 1)
+        _s += "red";
+      else
+        _s += "black";
+      _s += "]\n";
+      _s += parent_info + "->" + t_node->info + '\n';
+    } else {
+      _s += std::to_string(t_node->info) + " [shape=circle fontcolor=black color=";
+      if(t_node->is_red == 1)
+        _s += "red";
+      else
+        _s += "black";
+      _s += "]\n";
+      _s += std::to_string(parent_info) + "->" + std::to_string(t_node->info) + '\n';
+    }
+    if (t_node->left)
+      _s += _vis_gen(t_node->left, t_node->info);
+    if (t_node->right)
+      _s += _vis_gen(t_node->right, t_node->info);
+    return _s;
+  }
 public:
   /**
    *@brief Contructor for red black tree class.
@@ -472,6 +499,30 @@ public:
   Iterator end() {
     std::vector<T> ino = this->inorder();
     return Iterator(ino.size(), ino);
+  }
+
+  /**
+   *@brief visualize function
+   *@returns .dot file that can be previewed using graphviz in vscode.
+   */
+  void visualize() {
+    std::string _generated;
+    if(this->root){
+      if (std::is_same_v<T, char> || std::is_same_v<T, std::string>)
+        _generated += root->info;
+      else
+        _generated += std::to_string(root->info);
+      _generated += " [shape=circle fontcolor=black color=";
+      if(root->is_red == 1)
+        _generated += "red]\n";
+      else
+        _generated += "black]\n";
+      if(this->root->left)
+        _generated += this->_vis_gen(this->root->left, root->info);
+      if(this->root->right)
+        _generated += this->_vis_gen(this->root->right, root->info);
+    }
+    tree_visualization::visualize(_generated);
   }
 };
 

--- a/src/classes/tree/red_black_tree.h
+++ b/src/classes/tree/red_black_tree.h
@@ -263,7 +263,7 @@ private:
   }
 
   std::string _vis_gen(std::shared_ptr<node> t_node, T parent_info) {
-    std::string _s;
+    std::string _s = "";
     if (std::is_same_v<T, char> || std::is_same_v<T, std::string>) {
       _s += t_node->info + " [shape=circle fontcolor=black color=";
       if(t_node->is_red == 1)


### PR DESCRIPTION
For issue #71 

### For an example like this

```cpp
red_black_tree<int> rb({1, 2, 12, 14, 89, 3, 0, 13});
rb.visualize();
```

### This is the dot file generated

```dot
digraph Tree {
2 [shape=circle fontcolor=black color=black]
1 [shape=circle fontcolor=black color=black]
2->1
0 [shape=circle fontcolor=black color=red]
1->0
14 [shape=circle fontcolor=black color=red]
2->14
12 [shape=circle fontcolor=black color=black]
14->12
3 [shape=circle fontcolor=black color=red]
12->3
13 [shape=circle fontcolor=black color=red]
12->13
89 [shape=circle fontcolor=black color=black]
14->89
}
```

### And this is how it is rendered
![Screenshot from 2024-07-15 12-37-13](https://github.com/user-attachments/assets/394ba996-0b24-43c2-8778-d50718ff5606)