### PR TITLE
Fixed `operator<<` function

### DIFF
--- a/src/classes/tree/avl_tree.h
+++ b/src/classes/tree/avl_tree.h
@@ -211,7 +211,7 @@ public:
    * @brief operator << for avl_tree class
    */
   friend std::ostream & operator << (std::ostream &out, avl_tree<T> &t){
-    std::vector<std::vector<T> > order = t.inorder();
+    std::vector<T> order = t.inorder();
     for(int i = 0; i<order.size(); i++){
       if(i != order.size() - 1){
         out << order[i] << ", ";

--- a/src/classes/tree/bst.h
+++ b/src/classes/tree/bst.h
@@ -200,7 +200,7 @@ public:
    * @brief operator << for bst class
    */
   friend std::ostream & operator << (std::ostream &out, bst<T> &t){
-    std::vector<std::vector<T> > order = t.inorder();
+    std::vector<T> order = t.inorder();
     for(int i = 0; i<order.size(); i++){
       if(i != order.size() - 1){
         out << order[i] << ", ";

--- a/src/classes/tree/splay_tree.h
+++ b/src/classes/tree/splay_tree.h
@@ -213,7 +213,7 @@ public:
    * @brief operator << for splay tree class
    */
   friend std::ostream & operator << (std::ostream &out, splay_tree<T> &t){
-    std::vector<std::vector<T> > order = t.inorder();
+    std::vector<T> order = t.inorder();
     for(int i = 0; i<order.size(); i++){
       if(i != order.size() - 1){
         out << order[i] << ", ";

--- a/src/classes/tree/tree.h
+++ b/src/classes/tree/tree.h
@@ -186,7 +186,7 @@ public:
    * @brief operator << for bst class
    */
   friend std::ostream & operator << (std::ostream &out, tree<T> &t){
-    std::vector<std::vector<T> > order = t.inorder();
+    std::vector<T> order = t.inorder();
     for(int i = 0; i<order.size(); i++){
       if(i != order.size() - 1){
         out << order[i] << ", ";

--- a/tests/tree/avl.cc
+++ b/tests/tree/avl.cc
@@ -164,6 +164,14 @@ TEST_CASE("Testing get_root function in avl tree"){
   REQUIRE(t.get_root() == 36);
 }
 
+TEST_CASE("Testing operator << for avl tree") {
+    avl_tree<int> t({1, 10, 2, 8, 6, 5});
+    REQUIRE_NOTHROW(cout << t);
+
+    avl_tree<char> tt({'a', 'g', 'd', 'z', 'w', 'f'});
+    REQUIRE_NOTHROW(cout << tt);
+}
+
 #define TREE_VISUALIZATION_H
 #ifdef TREE_VISUALIZATION_H
 

--- a/tests/tree/bst.cc
+++ b/tests/tree/bst.cc
@@ -151,6 +151,14 @@ TEST_CASE("testing level order in bst"){
   REQUIRE(produced == sol);
 }
 
+TEST_CASE("Testing opearator << for bst") {
+    bst<int> t({1, 10, 5, 3, 9, 25});
+    REQUIRE_NOTHROW(cout << t);
+
+    bst<char> tt({'a', 'g', 'q', 'v', 'w'});
+    REQUIRE_NOTHROW(cout << tt);
+}
+
 #define TREE_VISUALIZATION_H
 #ifdef TREE_VISUALIZATION_H
 

--- a/tests/tree/splay_tree.cc
+++ b/tests/tree/splay_tree.cc
@@ -128,6 +128,14 @@ TEST_CASE("testing level order for splay tree"){
   REQUIRE(produced==sol);
 }
 
+TEST_CASE("Testing operator << for splay tree") {
+    splay_tree<int> t({1, 5, 3, 2, 9, 11});
+    REQUIRE_NOTHROW(cout << t);
+
+    splay_tree<char> tt({'a', 'b', 'w', 'z', 'f', 'd'});
+    REQUIRE_NOTHROW(cout << tt);
+}
+
 #define TREE_VISUALIZATION_H
 #ifdef TREE_VISUALIZATION_H
 

--- a/tests/tree/tree.cc
+++ b/tests/tree/tree.cc
@@ -53,6 +53,27 @@ TEST_CASE("testing level order traversal in tree class [TREECLASS]"){
   REQUIRE(produced == sol);
 }
 
+TEST_CASE("Testing operator << for tree") {
+    tree<int> t;
+    t.insert("", 1);
+    t.insert("l", 2);
+    t.insert("r", 3);
+    t.insert("ll", 4);
+    t.insert("lr", 5);
+    t.insert("rl", 6);
+    t.insert("rr", 7);
+    t.insert("lll", 8);
+    t.insert("llr", 9);
+    t.insert("lrl", 10);
+    REQUIRE_NOTHROW(cout << t);
+
+    tree<std::string> tt;
+    tt.insert("", "hello");
+    tt.insert("r", "world");
+    tt.insert("l", "universe");
+    REQUIRE_NOTHROW(cout << tt);
+}
+
 #define TREE_VISUALIZATION_H
 #ifdef TREE_VISUALIZATION_H
 


### PR DESCRIPTION
I have found same mistake in these files and modified it in order to match the `inorder()` function.